### PR TITLE
Fix mp4 precision of duration not accurate

### DIFF
--- a/lib/src/parsers/mp4.dart
+++ b/lib/src/parsers/mp4.dart
@@ -125,7 +125,7 @@ class MP4Parser extends TagParser {
       final timeScale = getUint32(bytes.sublist(12, 16));
       final timeUnit = getUint32(bytes.sublist(16, 20));
 
-      tags.duration = Duration(seconds: timeUnit ~/ timeScale);
+      tags.duration = Duration(microseconds: timeUnit * timeScale);
     } else if (box.type == "udta") {
       await parseRecurvise(reader, box);
     } else if (box.type == "ilst") {

--- a/test/mp4/mp4_test.dart
+++ b/test/mp4/mp4_test.dart
@@ -16,7 +16,7 @@ void main() {
     // expect(result.bitrate, equals(48000));
     expect(result.title, equals("Title"));
     expect(result.trackNumber, equals(1));
-    expect(result.duration, equals(Duration(seconds: 1)));
+    expect(result.duration, equals(Duration(microseconds: 1021333)));
     expect(result.totalDisc, equals(1));
     expect(result.lyrics, equals("Lyrics"));
     expect(result.trackTotal, equals(10));


### PR DESCRIPTION
The precision of duration of mp4 audio files is not accurate enough in milliseconds terms.
Therefor I would like to change the calculation of the duration object.

```
ffprobe -i  test/mp4/track.m4a -v quiet -print_format json -show_format -show_streams -hide_banner|grep duration
```
 "duration": "1.021333"