### PR TITLE
fix: read all metadata from Opus

### DIFF
--- a/lib/src/parsers/vorbis_comment.dart
+++ b/lib/src/parsers/vorbis_comment.dart
@@ -21,21 +21,13 @@ VorbisMetadata parseVorbisComment(
   final commentName = utf8.decode(commentBytes);
 
   dynamic value;
-  // if (commentName == "METADATA_BLOCK_PICTURE") {
-  //   final a = utf8.decode(bytes);
-  //   final imageValue = value = base64Decode(a);
-
-  //   metadata.pictures
-  //       .add(Picture(imageValue, "image/jpeg", PictureType.coverFront));
-  // } else {
   value = utf8.decode(bytes.sublist(i));
-  // }
 
   switch (commentName.toUpperCase()) {
     case 'METADATA_BLOCK_PICTURE':
       final imageValue = value = base64Decode(value);
       final buffer = ByteData.sublistView(imageValue);
-      var offset = 0;
+      int offset = 0;
 
       final pictureType = buffer.getUint32(offset);
       offset += 4;

--- a/test/ogg/ogg_test.dart
+++ b/test/ogg/ogg_test.dart
@@ -15,7 +15,7 @@ void main() {
     expect(result.sampleRate, equals(48000));
     expect(result.title, equals("Title"));
     expect(result.trackNumber, equals(1));
-    expect(result.duration, equals(Duration(seconds: 0)));
+    expect(result.duration, equals(Duration(seconds: 1)));
     expect(result.totalDisc, equals(1));
     expect(result.lyrics, equals("Lyrics"));
     expect(result.trackTotal, equals(10));


### PR DESCRIPTION
Sometimes, the metadata in the OGG container for the Opus file is big because it contains a heavy image (~800kB).

We need to handle the pages differently. The current solution works but it's not efficient at all.