### PR TITLE
fix: exit if MP4 is malformed

### DIFF
--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -159,9 +159,12 @@ AudioMetadata readMetadata(File track, {bool getImage = false}) {
 
       return a;
     }
-  } catch (e, trace) {
-    print(trace);
-    throw MetadataParserException(track: track, message: e.toString());
+  } on MetadataParserException catch (e, s) {
+    Error.throwWithStackTrace(
+        MetadataParserException(track: track, message: e.message), s);
+  } catch (e, s) {
+    Error.throwWithStackTrace(
+        MetadataParserException(track: track, message: e.toString()), s);
   }
 
   throw NoMetadataParserException(

--- a/lib/src/parsers/mp4.dart
+++ b/lib/src/parsers/mp4.dart
@@ -105,9 +105,18 @@ class MP4Parser extends TagParser {
     final parser = ByteData.sublistView(headerBytes);
 
     final boxSize = parser.getUint32(0);
-    final boxName = String.fromCharCodes(headerBytes.sublist(4));
+    final boxNameBytes = headerBytes.sublist(4);
 
-    return BoxHeader(boxSize, boxName);
+    // throw error if we don't have a correct box name
+    if (boxNameBytes[0] == 0 &&
+        boxNameBytes[1] == 0 &&
+        boxNameBytes[2] == 0 &&
+        boxNameBytes[3] == 0) {
+      throw MetadataParserException(
+          track: File(""), message: "malformed MP4 file");
+    }
+
+    return BoxHeader(boxSize, String.fromCharCodes(boxNameBytes));
   }
 
   ///

--- a/lib/src/parsers/mp4.dart
+++ b/lib/src/parsers/mp4.dart
@@ -73,7 +73,7 @@ class MP4Parser extends TagParser {
 
   @override
   ParserTag parse(RandomAccessFile reader) {
-    reader.setPositionSync(4);
+    reader.setPositionSync(0);
 
     final lengthFile = reader.lengthSync();
 

--- a/lib/src/parsers/mp4.dart
+++ b/lib/src/parsers/mp4.dart
@@ -113,7 +113,7 @@ class MP4Parser extends TagParser {
         boxNameBytes[2] == 0 &&
         boxNameBytes[3] == 0) {
       throw MetadataParserException(
-          track: File(""), message: "malformed MP4 file");
+          track: File(""), message: "Malformed MP4 file");
     }
 
     return BoxHeader(boxSize, String.fromCharCodes(boxNameBytes));

--- a/lib/src/parsers/mp4.dart
+++ b/lib/src/parsers/mp4.dart
@@ -195,10 +195,13 @@ class MP4Parser extends TagParser {
           break;
 
         case "covr":
-          tags.picture = Picture(
-              bytes.sublist(16),
-              lookupMimeType("no path", headerBytes: bytes.sublist(16)) ?? "",
-              PictureType.coverFront);
+          if (fetchImage) {
+            final imageData = bytes.sublist(16);
+            tags.picture = Picture(
+                imageData,
+                lookupMimeType("no path", headerBytes: imageData) ?? "",
+                PictureType.coverFront);
+          }
         case "trkn":
           final a = getUint16(bytes.sublist(18, 20));
           final totalTracks = getUint16(bytes.sublist(20, 22));

--- a/test/mp4/mp4_test.dart
+++ b/test/mp4/mp4_test.dart
@@ -13,13 +13,13 @@ void main() {
     expect(result.artist, equals("Artist"));
     expect(result.discNumber, equals(1));
     expect(result.sampleRate, equals(48000));
-    // expect(result.bitrate, equals(48000));
     expect(result.title, equals("Title"));
     expect(result.trackNumber, equals(1));
     expect(
-        result.duration!.inMicroseconds -
-            Duration(microseconds: 1021333).inMicroseconds,
-        lessThanOrEqualTo(1000000));
+      result.duration!.inMicroseconds -
+          Duration(microseconds: 1021333).inMicroseconds,
+      lessThanOrEqualTo(1000000),
+    );
     expect(result.totalDisc, equals(1));
     expect(result.lyrics, equals("Lyrics"));
     expect(result.trackTotal, equals(10));
@@ -35,5 +35,17 @@ void main() {
     expect(result.pictures.first.pictureType, PictureType.coverFront);
     expect(result.pictures.first.bytes,
         File("test/data/cover.png").readAsBytesSync());
+  });
+
+  test("Complex date", () {
+    final track = File('./test/mp4/ahah.m4a');
+    final result = readMetadata(track, getImage: true);
+
+    expect(result.title, "Sexy Ladies (Remix) [feat. 50 Cent]");
+    expect(result.album, "FutureSex/LoveSounds (Deluxe Edition)");
+    expect(result.artist, "Justin Timberlake");
+    expect(result.year, (DateTime.utc(2006, 9, 12)));
+    expect(result.trackNumber, 15);
+    expect(result.trackTotal, 15);
   });
 }


### PR DESCRIPTION
It seems that if the MP4 is malformed, we can be stuck in an infinite loop. In fact, it seems it's we are lock in a very slow loop that reads 28 bytes at each iteration.

Now, if the box name is incorrect, we throw an error.

Some minor optimization for MP4.