### PR TITLE
fix: ID3v2 wasn't parsing description as UTF-16

### DIFF
--- a/lib/src/parsers/id3v2.dart
+++ b/lib/src/parsers/id3v2.dart
@@ -556,9 +556,10 @@ class ID3v2Parser extends TagParser {
   }
 
   Picture getPicture(Uint8List content) {
-    var offset = 1;
+    int offset = 0;
 
     final reader = ByteData.sublistView(content);
+    final encoding = reader.getUint8(offset++);
 
     final mimetype = [reader.getUint8(offset++)];
 
@@ -572,13 +573,17 @@ class ID3v2Parser extends TagParser {
 
     offset++;
 
-    final description = [reader.getUint8(offset)];
-    offset += 1;
+    final description = [reader.getInt8(offset)];
 
     while (description.last != 0) {
-      final a = reader.getUint8(offset);
-      description.add(a);
+      description.add(reader.getInt8(offset));
       offset++;
+    }
+
+    if (encoding == 1 || encoding == 2) {
+      while (reader.getInt8(offset) == 0) {
+        offset++;
+      }
     }
 
     return Picture(

--- a/lib/src/parsers/id3v2.dart
+++ b/lib/src/parsers/id3v2.dart
@@ -573,11 +573,10 @@ class ID3v2Parser extends TagParser {
 
     offset++;
 
-    final description = [reader.getInt8(offset)];
+    final description = [reader.getInt8(offset++)];
 
     while (description.last != 0) {
-      description.add(reader.getInt8(offset));
-      offset++;
+      description.add(reader.getInt8(offset++));
     }
 
     if (encoding == 1 || encoding == 2) {


### PR DESCRIPTION
A ID3v2's APIC frame (the picture) has a description. This description has text that can be encoded and latin1, utf8 and utf16. 

The current implementation wasn't using the UTF-16 so we could have a bad behavior with UTF-16.