### PR TITLE
fix: parse correctly the null character

### DIFF
--- a/lib/src/parsers/id3v2.dart
+++ b/lib/src/parsers/id3v2.dart
@@ -205,7 +205,6 @@ class ID3v2Parser extends TagParser {
 
       // 10 -> frame header
       offset = offset + 10 + frame.size;
-
       processFrame(frame.id, frame.size);
     }
 
@@ -674,7 +673,7 @@ class ID3v2Parser extends TagParser {
     return tagIdentity == "TAG";
   }
 
-  int _parseYear(String year) {
+  int? _parseYear(String year) {
     if (year.contains("-")) {
       return int.parse(year.split("-").first);
     } else if (year.contains("/")) {

--- a/lib/src/parsers/id3v2.dart
+++ b/lib/src/parsers/id3v2.dart
@@ -675,11 +675,11 @@ class ID3v2Parser extends TagParser {
 
   int? _parseYear(String year) {
     if (year.contains("-")) {
-      return int.parse(year.split("-").first);
+      return int.tryParse(year.split("-").first);
     } else if (year.contains("/")) {
-      return int.parse(year.split("/").first);
+      return int.tryParse(year.split("/").first);
     } else {
-      return int.parse(year);
+      return int.tryParse(year);
     }
   }
 


### PR DESCRIPTION
Some ID3v2 have an \0 null character as a year. `int.parse()`throws an exception if it can't translate the string into an integer.