### PR TITLE
refactor: cleaner `write` API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,17 @@
-A pure-Dart package for reading and writing metadata for different audio format
+# Audio Metadata Reader
 
-| File Format | Metadata Format(s)  | Read | Write |
-| ----------- | ------------------- | ---- | ----- |
-| MP3         | `ID3v1` `ID3v2`     | ✅   | ❌    |
-| MP4         | `iTunes-style ilst` | ✅   | ❌    |
-| FLAC        | `Vorbis Comments`   | ✅   | ❌    |
-| OGG         | `Vorbis Comments`   | ✅   | ❌    |
-| Opus        | `Vorbis Comments`   | ✅   | ❌    |
-| WAV         | `RIFF`              | ✅   | ❌    |
+A pure Dart package for reading and writing metadata in various audio formats.
 
-It's still in development and there's some metadat format that I could implement or some information the library could return. Just open an issue for that.
+| File Format | Metadata Format(s)    | Read | Write |
+|-------------|------------------------|------|-------|
+| MP3         | `ID3v1`, `ID3v2`        | ✅   | ✅    |
+| MP4         | `iTunes-style ilst`     | ✅   | ✅    |
+| FLAC        | `Vorbis Comments`       | ✅   | ✅    |
+| OGG         | `Vorbis Comments`       | ✅   | ❌    |
+| Opus        | `Vorbis Comments`       | ✅   | ❌    |
+| WAV         | `RIFF`                  | ✅   | ✅    |
+
+This package is still under active development. If there's a metadata format you'd like to see supported or specific information you’d like the library to expose, feel free to open an issue.
 
 ## Usage
 
@@ -17,13 +19,12 @@ It's still in development and there's some metadat format that I could implement
 
 ```dart
 import 'dart:io';
-
 import 'package:audio_metadata_reader/audio_metadata_reader.dart';
 
 void main() {
   final track = File("Pieces.mp3");
 
-  // Getting the image of a track can be heavy and slow the reading
+  // Fetching images can slow down metadata reading
   final metadata = readMetadata(track, getImage: false);
 
   print(metadata.title);
@@ -33,67 +34,83 @@ void main() {
 
 ### Write
 
-This use case is a bit more complicated. You have to manipulate the raw metadata and update the good field.
-
 ```dart
 void main() {
-  final fullMetadata = readAllMetadata(track);
+  // Use a switch if you want to update metadata based on the file type
+  updateMetadata(
+    track,
+    (metadata) {
+      switch (metadata) {
+        case Mp3Metadata m:
+          m.songName = "New title";
+          break;
+        case Mp4Metadata m:
+          m.title = "New title";
+          break;
+        case VorbisMetadata m:
+          m.title = ["New title"];
+          break;
+        case RiffMetadata m:
+          m.title = "New title";
+      }
+    },
+  );
 
-  switch (fullMetadata) {
-    case Mp3Metadata m:
-      m.songName = "New title";
-      break;
-    case Mp4Metadata m:
-      m.title = "New title";
-      break;
-    case VorbisMetadata m:
-      m.title = ["New title"];
-      break;
-  }
-
-  writeMetadata(track, fullMetadata);
+  // Or use extension methods for common metadata updates
+  updateMetadata(
+    track,
+    (metadata) {
+      metadata.setTitle("New title");
+      metadata.setArtist("New artist");
+      metadata.setAlbum("New album");
+      metadata.setTrackNumber(1);
+      metadata.setYear(DateTime(2014));
+      metadata.setLyrics("I'm singing");
+      metadata.setGenres(["Rock", "Metal", "Salsa"]);
+      metadata.setPictures([
+        Picture(Uint8List.fromList([]), "image/png", PictureType.coverFront)
+      ]);
+    },
+  );
 }
 ```
 
-Also, all the ID3v2 metadata will be written in the minor version 4.
-
 ## Performance
 
-By running the following code on my laptop with a SSD, it ables to get the metadata of 3392 tracks in less than 200ms (if we don't fetch the covers). With the covers, about 400ms.
+On my laptop with an SSD, the library can process metadata from **3,392 tracks in under 200ms** — assuming covers aren't fetched. With covers, it's around **400ms**.
 
 ```dart
 import 'dart:io';
-
 import 'package:audio_metadata_reader/audio_metadata_reader.dart';
 
 void main() {
   final folder = Directory(r"music folder")
       .listSync(recursive: true)
       .whereType<File>()
-      .where((element) =>
-          element.path.contains("mp4") ||
-          element.path.contains("m4a") ||
-          element.path.contains("mp3") ||
-          element.path.contains("flac"))
+      .where((file) =>
+          file.path.endsWith(".mp4") ||
+          file.path.endsWith(".m4a") ||
+          file.path.endsWith(".mp3") ||
+          file.path.endsWith(".flac"))
       .toList();
 
   print("Number of tracks: ${folder.length}");
 
-  final init = DateTime.now();
+  final start = DateTime.now();
 
-  for(final file in folder) {
+  for (final file in folder) {
     readMetadata(file, getImage: false);
   }
 
   final end = DateTime.now();
-
-  print(end.difference(init));
+  print("Duration: ${end.difference(start)}");
 }
 ```
 
+
 ## Anonymize a Music Track
 
-If you need to send a track for issue reporting or testing, you should anonymize it. This means converting the actual track into random noise. You can use `ffmpeg` for this purpose.
+If you need to report an issue or test the library without sharing private audio, you can anonymize a track by replacing its audio with white noise using `ffmpeg`:
 
 ```bash
 ffmpeg -i <your_track> -f lavfi -t 5 -i "anoisesrc=color=white:duration=5" -map_metadata 0 -map 1:a -t 5 <output_track>

--- a/example/main.dart
+++ b/example/main.dart
@@ -22,7 +22,7 @@ void main() {
 
   print("Now we are going to rewrite the metadata");
 
-  // Use the switch if you want to update metadata for a
+  // Use the switch if you want to update metadata for a specific format
   updateMetadata(
     track,
     (metadata) {
@@ -48,9 +48,8 @@ void main() {
     (metadata) {
       metadata.setTitle("New title");
       metadata.setArtist("New artist");
-      metadata.setAlbum("New artist");
+      metadata.setAlbum("New album");
       metadata.setTrackNumber(1);
-      metadata.setTrackNumber(12);
       metadata.setYear(DateTime(2014));
       metadata.setLyrics("I'm singing");
       metadata.setGenres(["Rock", "Metal", "Salsa"]);

--- a/example/main.dart
+++ b/example/main.dart
@@ -1,12 +1,12 @@
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:audio_metadata_reader/audio_metadata_reader.dart';
-import 'package:audio_metadata_reader/src/metadata/base.dart';
-import 'package:audio_metadata_reader/src/writer.dart';
 
 void main() {
   final track = File("Pieces.mp3");
 
+  // Returns a condensate
   // Getting the image of a track can be heavy and slow the reading
   final metadata = readMetadata(track, getImage: false);
 
@@ -15,23 +15,48 @@ void main() {
   print(metadata.duration);
   // etc...
 
+  // If you need ALL the metadata of a file (eg. MP3 has bpm)
+  // Later you need to check the type of the metadata with a switch
+  // ignore: unused_local_variable
+  final allMetadata = readAllMetadata(track, getImage: true);
+
   print("Now we are going to rewrite the metadata");
 
-  final fullMetadata = readAllMetadata(track);
+  // Use the switch if you want to update metadata for a
+  updateMetadata(
+    track,
+    (metadata) {
+      switch (metadata) {
+        case Mp3Metadata m:
+          m.songName = "New title";
+          break;
+        case Mp4Metadata m:
+          m.title = "New title";
+          break;
+        case VorbisMetadata m:
+          m.title = ["New title"];
+          break;
+        case RiffMetadata m:
+          m.title = "New title";
+      }
+    },
+  );
 
-  switch (fullMetadata) {
-    case Mp3Metadata m:
-      m.songName = "New title";
-      break;
-    case Mp4Metadata m:
-      m.title = "New title";
-      break;
-    case VorbisMetadata m:
-      m.title = ["New title"];
-      break;
-    case RiffMetadata m:
-      m.title = "New title";
-  }
-
-  writeMetadata(track, fullMetadata);
+  // Or use the extension methods to update common properties
+  updateMetadata(
+    track,
+    (metadata) {
+      metadata.setTitle("New title");
+      metadata.setArtist("New artist");
+      metadata.setAlbum("New artist");
+      metadata.setTrackNumber(1);
+      metadata.setTrackNumber(12);
+      metadata.setYear(DateTime(2014));
+      metadata.setLyrics("I'm singing");
+      metadata.setGenres(["Rock", "Metal", "Salsa"]);
+      metadata.setPictures([
+        Picture(Uint8List.fromList([]), "image/png", PictureType.coverFront)
+      ]);
+    },
+  );
 }

--- a/lib/audio_metadata_reader.dart
+++ b/lib/audio_metadata_reader.dart
@@ -17,7 +17,7 @@ export 'src/parsers/ogg.dart' show OGGParser;
 
 export 'src/writers/id3v4_writer.dart' show Id3v4Writer;
 export 'src/writers/flac_writer.dart' show FlacWriter;
-export 'src/writers/id3v1_writer.dart' show Id3v1Writer;
+export 'src/writers/id3v1_writer.dart' show ID3v1Writer;
 export 'src/writers/mp4_writer.dart' show Mp4Writer;
 export 'src/writers/riff_writer.dart' show RiffWriter;
 

--- a/lib/audio_metadata_reader.dart
+++ b/lib/audio_metadata_reader.dart
@@ -7,6 +7,7 @@ export 'src/utils/metadata_parser_exception.dart'
 export 'src/parser.dart' show readMetadata;
 export 'src/utils/metadata_parser_exception.dart' show MetadataParserException;
 export 'src/parser.dart' show readMetadata, readAllMetadata;
+export 'src/writer.dart' show updateMetadata, writeMetadata;
 
 export 'src/parsers/id3v1.dart' show ID3v1Parser;
 export 'src/parsers/id3v2.dart' show ID3v2Parser;
@@ -15,8 +16,15 @@ export 'src/parsers/mp4.dart' show MP4Parser;
 export 'src/parsers/ogg.dart' show OGGParser;
 
 export 'src/writers/id3v4_writer.dart' show Id3v4Writer;
-export 'src/utils/metadata_parser_exception.dart'
-    show MetadataParserException, NoMetadataParserException;
-export 'src/parser.dart' show readMetadata;
-export 'src/utils/metadata_parser_exception.dart' show MetadataParserException;
-export 'src/parser.dart' show readMetadata, readAllMetadata;
+export 'src/writers/flac_writer.dart' show FlacWriter;
+export 'src/writers/id3v1_writer.dart' show Id3v1Writer;
+export 'src/writers/mp4_writer.dart' show Mp4Writer;
+export 'src/writers/riff_writer.dart' show RiffWriter;
+
+export 'src/metadata/base.dart'
+    show
+        Mp3Metadata,
+        Mp4Metadata,
+        RiffMetadata,
+        VorbisMetadata,
+        CommonMetadataSetters;

--- a/lib/src/metadata/base.dart
+++ b/lib/src/metadata/base.dart
@@ -107,3 +107,160 @@ PictureType getPictureTypeEnum(int value) {
       return PictureType.other;
   }
 }
+
+extension CommonMetadataSetters on ParserTag {
+  void setTitle(String? title) {
+    switch (this) {
+      case Mp3Metadata m:
+        m.songName = title;
+        break;
+      case Mp4Metadata m:
+        m.title = title;
+        break;
+      case VorbisMetadata m:
+        m.title = title == null ? [] : [title];
+        break;
+      case RiffMetadata m:
+        m.title = title;
+        break;
+    }
+  }
+
+  void setArtist(String? artist) {
+    switch (this) {
+      case Mp3Metadata m:
+        m.bandOrOrchestra = artist;
+        break;
+      case Mp4Metadata m:
+        m.artist = artist;
+        break;
+      case VorbisMetadata m:
+        m.artist = artist == null ? m.artist : [artist];
+        break;
+      case RiffMetadata m:
+        m.artist = artist;
+        break;
+    }
+  }
+
+  void setAlbum(String? album) {
+    switch (this) {
+      case Mp3Metadata m:
+        m.album = album;
+        break;
+      case Mp4Metadata m:
+        m.album = album;
+        break;
+      case VorbisMetadata m:
+        m.album = album == null ? [] : [album];
+        break;
+      case RiffMetadata m:
+        m.album = album;
+        break;
+    }
+  }
+
+  void setYear(DateTime? year) {
+    switch (this) {
+      case Mp3Metadata m:
+        m.year = year?.year;
+        break;
+      case Mp4Metadata m:
+        m.year = year;
+        break;
+      case VorbisMetadata m:
+        m.date = year == null ? [] : [year];
+        break;
+      case RiffMetadata m:
+        m.year = year;
+        break;
+    }
+  }
+
+  void setPictures(List<Picture> pictures) {
+    switch (this) {
+      case Mp3Metadata m:
+        m.pictures = pictures;
+        break;
+      case Mp4Metadata m:
+        m.picture = pictures.firstOrNull;
+        break;
+      case VorbisMetadata m:
+        m.pictures = pictures;
+        break;
+      case RiffMetadata m:
+        m.pictures = pictures;
+        break;
+    }
+  }
+
+  void setTrackNumber(int? trackNumber) {
+    switch (this) {
+      case Mp3Metadata m:
+        m.trackNumber = trackNumber;
+        break;
+      case Mp4Metadata m:
+        m.trackNumber = trackNumber;
+        break;
+      case VorbisMetadata m:
+        m.trackNumber = trackNumber == null ? [] : [trackNumber];
+        break;
+      case RiffMetadata m:
+        m.trackNumber = trackNumber;
+        break;
+    }
+  }
+
+  void setTrackTotal(int? trackTotal) {
+    switch (this) {
+      case Mp3Metadata m:
+        m.trackTotal = trackTotal;
+        break;
+      case Mp4Metadata m:
+        m.totalTracks = trackTotal;
+        break;
+      case VorbisMetadata m:
+        m.trackTotal = trackTotal;
+        break;
+      case RiffMetadata m:
+        m.trackNumber = trackTotal;
+        break;
+    }
+  }
+
+  /// Update the lyrics.
+  ///
+  /// Has no effect on RIFF metadata (`.wav`)
+  void setLyrics(String? lyric) {
+    switch (this) {
+      case Mp3Metadata m:
+        m.lyric = lyric;
+        break;
+      case Mp4Metadata m:
+        m.lyrics = lyric;
+        break;
+      case VorbisMetadata m:
+        m.lyric = lyric;
+        break;
+      case RiffMetadata():
+        break;
+    }
+  }
+
+  void setGenres(List<String> genres) {
+    switch (this) {
+      case Mp3Metadata m:
+        m.genres = genres;
+        break;
+      case Mp4Metadata m:
+        m.genre = genres.firstOrNull;
+        break;
+      case VorbisMetadata m:
+        m.genres = genres;
+        break;
+      case RiffMetadata m:
+        m.genre = genres.firstOrNull;
+        break;
+    }
+  }
+}

--- a/lib/src/writer.dart
+++ b/lib/src/writer.dart
@@ -29,6 +29,6 @@ void writeMetadata(File track, ParserTag metadata) {
   } else if (RiffParser.canUserParser(reader)) {
     RiffWriter().write(track, metadata as RiffMetadata);
   } else if (ID3v1Parser.canUserParser(reader)) {
-    Id3v1Writer().write(track, metadata as Mp3Metadata);
+    ID3v1Writer().write(track, metadata as Mp3Metadata);
   }
 }

--- a/lib/src/writer.dart
+++ b/lib/src/writer.dart
@@ -2,11 +2,33 @@ import 'dart:io';
 
 import 'package:audio_metadata_reader/audio_metadata_reader.dart';
 import 'package:audio_metadata_reader/src/metadata/base.dart';
+import 'package:audio_metadata_reader/src/parsers/riff.dart';
 
+/// Reads the metadata, allows modification via [updater], and writes it back.
+///
+/// The [updater] receives the specific metadata object (e.g Mp3Metadata).
+/// You can modify this object directly within the callback.
+void updateMetadata(File track, void Function(ParserTag metadata) updater) {
+  final metadata = readAllMetadata(track);
+
+  updater(metadata);
+
+  writeMetadata(track, metadata);
+}
+
+/// Write the [metadata] into the [track]
 void writeMetadata(File track, ParserTag metadata) {
   final reader = track.openSync();
 
   if (ID3v2Parser.canUserParser(reader)) {
     Id3v4Writer().write(track, metadata as Mp3Metadata);
+  } else if (MP4Parser.canUserParser(reader)) {
+    Mp4Writer().write(track, metadata as Mp4Metadata);
+  } else if (FlacParser.canUserParser(reader)) {
+    FlacWriter().write(track, metadata as VorbisMetadata);
+  } else if (RiffParser.canUserParser(reader)) {
+    RiffWriter().write(track, metadata as RiffMetadata);
+  } else if (ID3v1Parser.canUserParser(reader)) {
+    Id3v1Writer().write(track, metadata as Mp3Metadata);
   }
 }

--- a/lib/src/writers/base_writer.dart
+++ b/lib/src/writers/base_writer.dart
@@ -1,0 +1,9 @@
+import 'dart:io';
+
+import 'package:audio_metadata_reader/src/metadata/base.dart';
+
+/// Base class for all the metadata writer
+abstract class BaseMetadataWriter<T extends ParserTag> {
+  /// Write the [metadata] into the [file]
+  void write(File file, T metadata);
+}

--- a/lib/src/writers/flac_writer.dart
+++ b/lib/src/writers/flac_writer.dart
@@ -3,11 +3,12 @@ import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:audio_metadata_reader/audio_metadata_reader.dart';
-import 'package:audio_metadata_reader/src/metadata/base.dart';
 import 'package:audio_metadata_reader/src/parsers/flac.dart';
 import 'package:audio_metadata_reader/src/utils/bit_manipulator.dart';
+import 'package:audio_metadata_reader/src/writers/base_writer.dart';
 
-class FlacWriter {
+class FlacWriter extends BaseMetadataWriter<VorbisMetadata> {
+  @override
   void write(File file, VorbisMetadata metadata) {
     final builder = BytesBuilder();
 

--- a/lib/src/writers/id3v1_writer.dart
+++ b/lib/src/writers/id3v1_writer.dart
@@ -7,7 +7,7 @@ import 'package:audio_metadata_reader/src/writers/base_writer.dart'; // For enco
 class Id3v1Writer extends BaseMetadataWriter<Mp3Metadata> {
   @override
   void write(File file, Mp3Metadata metadata) {
-    final reader = file.openSync();
+    final reader = file.openSync(mode: FileMode.append);
     // 1. Seek to the ID3v1 tag position (128 bytes from the end)
     reader.setPositionSync(reader.lengthSync());
 

--- a/lib/src/writers/id3v1_writer.dart
+++ b/lib/src/writers/id3v1_writer.dart
@@ -4,7 +4,7 @@ import 'dart:convert';
 import 'package:audio_metadata_reader/src/metadata/base.dart';
 import 'package:audio_metadata_reader/src/writers/base_writer.dart'; // For encoding strings to bytes
 
-class Id3v1Writer extends BaseMetadataWriter<Mp3Metadata> {
+class ID3v1Writer extends BaseMetadataWriter<Mp3Metadata> {
   @override
   void write(File file, Mp3Metadata metadata) {
     final reader = file.openSync(mode: FileMode.append);

--- a/lib/src/writers/id3v4_writer.dart
+++ b/lib/src/writers/id3v4_writer.dart
@@ -4,6 +4,7 @@ import 'dart:typed_data';
 
 import 'package:audio_metadata_reader/src/metadata/base.dart';
 import 'package:audio_metadata_reader/src/parsers/tag_parser.dart';
+import 'package:audio_metadata_reader/src/writers/base_writer.dart';
 
 class TagHeader {
   final int majorVersion;
@@ -18,7 +19,8 @@ class TagHeader {
   int get version => majorVersion * 100 + minorVersion;
 }
 
-class Id3v4Writer {
+class Id3v4Writer extends BaseMetadataWriter<Mp3Metadata> {
+  @override
   void write(File file, Mp3Metadata metadata) {
     // check if the file has an ID3 metadata
     final size = file.lengthSync();

--- a/lib/src/writers/mp4_writer.dart
+++ b/lib/src/writers/mp4_writer.dart
@@ -3,13 +3,14 @@ import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:audio_metadata_reader/audio_metadata_reader.dart';
-import 'package:audio_metadata_reader/src/metadata/base.dart';
 import 'package:audio_metadata_reader/src/parsers/mp4.dart';
 import 'package:audio_metadata_reader/src/utils/bit_manipulator.dart';
+import 'package:audio_metadata_reader/src/writers/base_writer.dart';
 
-class Mp4Writer {
+class Mp4Writer extends BaseMetadataWriter<Mp4Metadata> {
   late Mp4Metadata mp4metadata;
 
+  @override
   void write(File file, Mp4Metadata metadata) {
     mp4metadata = metadata;
     final reader = file.openSync();

--- a/lib/src/writers/riff_writer.dart
+++ b/lib/src/writers/riff_writer.dart
@@ -5,11 +5,13 @@ import 'dart:typed_data';
 import 'package:audio_metadata_reader/src/metadata/base.dart';
 import 'package:audio_metadata_reader/src/utils/bit_manipulator.dart';
 import 'package:audio_metadata_reader/src/utils/buffer.dart';
+import 'package:audio_metadata_reader/src/writers/base_writer.dart';
 
-class RiffWriter {
+class RiffWriter extends BaseMetadataWriter<RiffMetadata> {
   late RiffMetadata metadata;
   late final Buffer buffer;
 
+  @override
   void write(File file, RiffMetadata metadata) {
     this.metadata = metadata;
     final builder = BytesBuilder();

--- a/test/writers/id3v1_writer_test.dart
+++ b/test/writers/id3v1_writer_test.dart
@@ -1,6 +1,5 @@
 import 'dart:io';
-import 'package:audio_metadata_reader/audio_metadata_reader.dart';
-import 'package:audio_metadata_reader/src/constants/id3_genres.dart';
+import 'package:audio_metadata_reader/src/metadata/base.dart';
 import 'package:audio_metadata_reader/src/utils/pad_bit.dart';
 import 'package:audio_metadata_reader/src/writers/id3v1_writer.dart';
 import 'package:test/test.dart';
@@ -14,16 +13,15 @@ void main() {
     final writer = tempFile.openSync(mode: FileMode.write);
 
     writer.writeFromSync([1, 2, 3, 4, 5]);
+    writer.closeSync();
 
-    final metadata = AudioMetadata(
-      title: 'Test Title',
-      artist: 'Test Artist',
-      album: 'Test Album',
-      year: DateTime(2023),
-      file: File(""),
-    );
+    final metadata = Mp3Metadata()
+      ..songName = 'Test Title'
+      ..bandOrOrchestra = 'Test Artist'
+      ..album = 'Test Album'
+      ..year = 2023;
 
-    Id3v1Writer().write(writer, metadata);
+    Id3v1Writer().write(tempFile, metadata);
 
     final fileBytes = tempFile.readAsBytesSync();
     final id3v1Bytes = fileBytes.sublist(fileBytes.length - 128);
@@ -31,13 +29,13 @@ void main() {
     // 7. Assert that the written bytes match the expected bytes
     expect(id3v1Bytes.sublist(0, 3), equals("TAG".codeUnits));
     expect(id3v1Bytes.sublist(3, 33),
-        equals(metadata.title!.codeUnits.padBitRight(30, 0)));
+        equals(metadata.songName!.codeUnits.padBitRight(30, 0)));
     expect(id3v1Bytes.sublist(33, 63),
-        equals(metadata.artist!.codeUnits.padBitRight(30, 0)));
+        equals(metadata.bandOrOrchestra!.codeUnits.padBitRight(30, 0)));
     expect(id3v1Bytes.sublist(63, 93),
         equals(metadata.album!.codeUnits.padBitRight(30, 0)));
     expect(id3v1Bytes.sublist(93, 97),
-        equals(metadata.year!.year.toString().codeUnits));
+        equals(metadata.year!.toString().codeUnits));
     expect(id3v1Bytes.sublist(97, 127), equals(List.filled(30, 0)));
     expect(id3v1Bytes[127], equals(255));
 

--- a/test/writers/id3v1_writer_test.dart
+++ b/test/writers/id3v1_writer_test.dart
@@ -21,7 +21,7 @@ void main() {
       ..album = 'Test Album'
       ..year = 2023;
 
-    Id3v1Writer().write(tempFile, metadata);
+    ID3v1Writer().write(tempFile, metadata);
 
     final fileBytes = tempFile.readAsBytesSync();
     final id3v1Bytes = fileBytes.sublist(fileBytes.length - 128);


### PR DESCRIPTION
I added functions to :
- `readAllMetadata`: get all the metadata of a file. A MP3 has way more metadata than the object returned by `readMetadata`
- `updateMetadata`: update the metadata of the given file

I added an extension on `ParserTag` to facilitate the metadata update : `setTitle(...)` , `setAlbum(...)`...

And a base class for all the metadata writers.