### PR TITLE
fix: write and read number in MP3

### DIFF
--- a/lib/src/parsers/id3v2.dart
+++ b/lib/src/parsers/id3v2.dart
@@ -443,12 +443,14 @@ class ID3v2Parser extends TagParser {
         },
       "TLEN" => () {
           final content = buffer.read(size);
-          final time = int.parse(getTextFromFrame(content));
+          final time = int.tryParse(getTextFromFrame(content));
 
-          if ((time / 1000) < 1) {
-            metadata.duration = Duration(seconds: time);
-          } else {
-            metadata.duration = Duration(milliseconds: time);
+          if (time != null) {
+            if ((time / 1000) < 1) {
+              metadata.duration = Duration(seconds: time);
+            } else {
+              metadata.duration = Duration(milliseconds: time);
+            }
           }
         },
       "TMED" => () {

--- a/lib/src/writers/id3v4_writer.dart
+++ b/lib/src/writers/id3v4_writer.dart
@@ -148,7 +148,9 @@ class Id3v4Writer extends BaseMetadataWriter<Mp3Metadata> {
       if (metadata.trackTotal != null) {
         _writeFrame(
             builder, "TRCK", "${metadata.trackNumber}/${metadata.trackTotal}");
-      } else {}
+      } else {
+        _writeFrame(builder, "TRCK", "${metadata.trackNumber}");
+      }
     }
     if (metadata.recordingDates != null) {
       _writeFrame(builder, "TRDA", metadata.recordingDates!);

--- a/lib/src/writers/id3v4_writer.dart
+++ b/lib/src/writers/id3v4_writer.dart
@@ -102,7 +102,7 @@ class Id3v4Writer extends BaseMetadataWriter<Mp3Metadata> {
     }
     if (metadata.duration != null) {
       final duration = metadata.duration!;
-      _writeFrame(builder, "TLEN", "${duration.inMilliseconds}}");
+      _writeFrame(builder, "TLEN", "${duration.inMilliseconds}");
     }
     if (metadata.mediatype != null) {
       _writeFrame(builder, "TMED", metadata.mediatype!);


### PR DESCRIPTION
Three bugs fixed here for the MP3 writer :

- When we write the `TLEN` frame, it was adding a `}` at the end of the value. So we had something like `1232}`. It was breaking the TLEN parser
- The `TLEN` frame parser was using `int.parse`. It breaks if the string is an incorrect integer. Now we use `int.tryParse`
- When we write the track number/total, it was writing only if we passed both of them. It's not required because it can only accept track number too