### PR TITLE
fix: write CD and genres for MP3

### DIFF
--- a/lib/src/metadata/base.dart
+++ b/lib/src/metadata/base.dart
@@ -263,4 +263,26 @@ extension CommonMetadataSetters on ParserTag {
         break;
     }
   }
+
+  /// Has no effect on RIFF metadata (`.wav`)
+  void setCD(int? cdNumber, int? discTotal) {
+    switch (this) {
+      case Mp3Metadata m:
+        if (cdNumber != null && discTotal == null)
+          m.partOfSet = "$cdNumber";
+        else if (cdNumber != null && discTotal != null)
+          m.partOfSet = "$cdNumber/$discTotal";
+        break;
+      case Mp4Metadata m:
+        m.discNumber = cdNumber;
+        m.totalDiscs = discTotal;
+        break;
+      case VorbisMetadata m:
+        m.discNumber = cdNumber;
+        m.discTotal = discTotal;
+        break;
+      case RiffMetadata():
+        break;
+    }
+  }
 }

--- a/lib/src/writers/id3v4_writer.dart
+++ b/lib/src/writers/id3v4_writer.dart
@@ -173,6 +173,12 @@ class Id3v4Writer extends BaseMetadataWriter<Mp3Metadata> {
     if (metadata.year != null) {
       _writeFrame(builder, "TYER", metadata.year!.toString());
     }
+    if (metadata.genres.isNotEmpty) {
+      final genresString = metadata.genres.join('/');
+      _writeFrame(builder, "TCON", genresString);
+    } else if (metadata.contentType != null) {
+      _writeFrame(builder, "TCON", metadata.contentType!);
+    }
   }
 
   void _writeFrame(BytesBuilder builder, String frameId, String data) {


### PR DESCRIPTION
We weren't writing CD data and genres. Now we do! 

Added the `setCD(...)` setter.