### PR TITLE
chore: bump `intl` and `test`

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: audio_metadata_reader
 description: A metadata reader for audio files. Support ID3, Vorbis comments and ILST itunes
-version: 1.4.1
+version: 1.4.2
 homepage: https://clementbeal.github.io/
 repository: https://github.com/ClementBeal/audio_metadata_reader
 issue_tracker: https://github.com/ClementBeal/audio_metadata_reader/issues
@@ -17,7 +17,7 @@ environment:
 
 dependencies:
   charset: ^2.0.1
-  intl: ^0.19.0
+  intl: ^0.20.2
   mime: ^2.0.0
 dev_dependencies:
-  test: ^1.25.8
+  test: ^1.26.2


### PR DESCRIPTION
Bumps `intl` and `test` dependencies to their latest versions.

Increases the package version to 1.4.2.