### PR TITLE
Bump intl version to match latest Flutter versions

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ environment:
 
 dependencies:
   charset: ^2.0.1
-  intl: ^0.19.0
+  intl: ^0.20.2
   mime: ^2.0.0
 dev_dependencies:
   test: ^1.25.8


### PR DESCRIPTION
This PR bumps the intl package version to 0.20.2 as mentioned in #81 


Package has been tested with this change and it works fine