### PR TITLE
BUG: Hard-coded filename instead of using the provided file parameter

### DIFF
--- a/lib/src/writers/mp4_writer.dart
+++ b/lib/src/writers/mp4_writer.dart
@@ -37,7 +37,7 @@ class Mp4Writer extends BaseMetadataWriter<Mp4Metadata> {
 
     reader.closeSync();
 
-    File("a_new.mp4").writeAsBytesSync(byteBuilder.toBytes());
+    file.writeAsBytesSync(byteBuilder.toBytes());
   }
 
   Uint8List _processBox(Uint8List data) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ environment:
 
 dependencies:
   charset: ^2.0.1
-  intl: ^0.20.2
+  intl: ^0.19.0
   mime: ^2.0.0
 dev_dependencies:
   test: ^1.26.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ environment:
 
 dependencies:
   charset: ^2.0.1
-  intl: ^0.19.0
+  intl: ^0.20.2
   mime: ^2.0.0
 dev_dependencies:
   test: ^1.26.2


### PR DESCRIPTION
`// Line 41 - BUG: Hard-coded filename instead of using the provided file parameter
File("a_new.mp4").writeAsBytesSync(byteBuilder.toBytes());
`

Current Issues with the Package:

❌ Writes to a hard-coded file "a_new.mp4"
❌ Does not use the file parameter passed into the function
❌ Causes a permission error due to attempting to write in the root directory

`//Fixed
file.writeAsBytesSync(byteBuilder.toBytes());`