### PR TITLE
Fix updating genres on id3v4

### DIFF
--- a/lib/src/writers/id3v4_writer.dart
+++ b/lib/src/writers/id3v4_writer.dart
@@ -59,9 +59,6 @@ class Id3v4Writer extends BaseMetadataWriter<Mp3Metadata> {
     if (metadata.composer != null) {
       _writeFrame(builder, "TCOM", metadata.composer!);
     }
-    if (metadata.contentType != null) {
-      _writeFrame(builder, "TCON", metadata.contentType!);
-    }
     if (metadata.copyrightMessage != null) {
       _writeFrame(builder, "TCOP", metadata.copyrightMessage!);
     }


### PR DESCRIPTION
## Files changed

- `/lib/src/writers/id3v4_writer.dart`

## Changes

- The 'TCON' frame was used for contentType and was changed to represent genres or contentType in a new version of id3. The new TCON update was correctly created but the old TCON update wasn't deleted. That's what I did.

## Fixes

fixes #89 