### PR TITLE
Fix setArtist tag for mp3

### DIFF
--- a/lib/src/metadata/base.dart
+++ b/lib/src/metadata/base.dart
@@ -129,7 +129,7 @@ extension CommonMetadataSetters on ParserTag {
   void setArtist(String? artist) {
     switch (this) {
       case Mp3Metadata m:
-        m.bandOrOrchestra = artist;
+        m.leadPerformer = artist;
         break;
       case Mp4Metadata m:
         m.artist = artist;


### PR DESCRIPTION
## Files changed

- `lib/src/metadata/base.dart`

## Changes

- In the `setArtist` function, when modifying the mp3 artist, the `bandOrOrchestra` tag was the one modified, even though it should be `leadPerformer`. The former corresponds to the Album Artist, the latter corresponds to the Track Artist (see photo).

## Photo

<img width="477" height="399" alt="artist" src="https://github.com/user-attachments/assets/fdfe7983-a3b1-4d4f-96ef-07beda8d5c27" />

*You can see that the Artist gets the "Lead performer" value and the Album Artist gets the "Band or Orchestra" value*

This was the code used:

```dart
updateMetadata(audioFile, (meta) {
      meta.setGenres(["newGenre10", "newGenre5"]);
      switch (meta) {
        case Mp3Metadata m:
          logger.log("Got here");
          m.leadPerformer = "Lead performer";
          m.bandOrOrchestra = "Band or orchestra";
          break;
        default:
          break;
      }
```
