### PR TITLE
fix: ID3 TOWN parsing and add regression test

### DIFF
--- a/lib/src/parsers/id3v2.dart
+++ b/lib/src/parsers/id3v2.dart
@@ -479,7 +479,7 @@ class ID3v2Parser extends TagParser {
         },
       "TOWN" => () {
           final content = buffer.read(size);
-          metadata.fileOwner == getTextFromFrame(content);
+          metadata.fileOwner = getTextFromFrame(content);
         },
       "TDRC" => () {
           final content = buffer.read(size);

--- a/test/writers/id3v4_writer_test.dart
+++ b/test/writers/id3v4_writer_test.dart
@@ -101,6 +101,24 @@ void main() {
       );
 
       test(
+        "Write and parse file owner (TOWN)",
+        () {
+          final writer = Id3v4Writer();
+          final file = createTemporaryFile("test.mp3", mp3FrameHeaderCBR());
+
+          final metadata = Mp3Metadata();
+          metadata.fileOwner = "owner@example.com";
+
+          writer.write(file, metadata);
+
+          final resultMetadata =
+              ID3v2Parser().parse(file.openSync()) as Mp3Metadata;
+
+          expect(resultMetadata.fileOwner, equals(metadata.fileOwner));
+        },
+      );
+
+      test(
         "Write a picture",
         () {
           final writer = Id3v4Writer();


### PR DESCRIPTION
This change fixes a small typo with a big impact: when reading the TOWN field (file owner) from MP3 metadata, the code was accidentally comparing values instead of saving the value. So even if the file owner existed in the tag, it was silently ignored.

I also added a test to prevent this from happening again. The test writes a file owner value into an MP3 tag, reads the file back, and checks that the same value is still there. This makes sure the field is now properly handled end to end.